### PR TITLE
Query optimization using prequeries (WITH prequery AS (...) SELECT ...)

### DIFF
--- a/misc/userful-queries/patient-id.sql
+++ b/misc/userful-queries/patient-id.sql
@@ -9,6 +9,9 @@ JOIN patient_birthdate_crypt pbc
 JOIN patient_name_crypt pnc
     ON  pnc.lastname_first_letter = p.lastname_first_letter
     AND pnc.id = p.name_crypt_id
+JOIN patient_ref_crypt prc
+    ON prc.one_char = p.ref_one_char
+    AND prc.id = p.ref_crypt_id
 WHERE pnc.lastname_first_letter = 'r'
 	AND pgp_sym_decrypt(pnc.lastname_for_cp_crypt, 'aaaaaaaxxxxxcccccc') = 'rosaine'
 	AND pgp_sym_decrypt(pnc.firstname_for_cp_crypt, 'aaaaaaaxxxxxcccccc') = 'michel'

--- a/src/Controller/AnalysisRequestCtrl/getAnalysesRequestsForListing.jl
+++ b/src/Controller/AnalysisRequestCtrl/getAnalysesRequestsForListing.jl
@@ -16,7 +16,7 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
 
     args_counter = 0
     queryString = ""
-    queryStringUsing = ""
+    prequeryString = ""
     queryArgs::Vector{Any} = []
 
     # If crypt password is given, set it as the first argument of the query
@@ -24,7 +24,17 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
         push!(queryArgs,cryptPwd)
     end
 
-    queryStringShared = "
+    prequeryString = "
+    SELECT  a.*,
+
+            -- The following are for joining with the main query
+            p.birth_year AS patient_birth_year,
+            p.birthdate_crypt_id AS patient_birthdate_crypt_id,
+            p.lastname_first_letter AS patient_lastname_first_letter,
+            p.name_crypt_id AS patient_name_crypt_id,
+            p.ref_one_char AS patient_ref_one_char,
+            p.ref_crypt_id AS patient_ref_crypt_id
+
     FROM analysis_request a
     INNER JOIN patient p
         ON p.id  = a.patient_id
@@ -33,7 +43,7 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
     "
 
     if !ismissing(cryptPwd)
-        queryStringShared *= "
+        prequeryString *= "
         JOIN patient_birthdate_crypt pbc
             ON  pbc.year = p.birth_year
             AND pbc.id = p.birthdate_crypt_id
@@ -46,7 +56,7 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
         "
     end
 
-    queryStringShared *= "
+    prequeryString *= "
     WHERE 1 = 1 -- for convenience
     "
 
@@ -89,11 +99,11 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
             if (nameInSelect == "patient_ref" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = lowercase(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND prc.one_char = \$$(args_counter += 1)"
                 push!(queryArgs, PatientCtrl.getRefOneChar(filterValue))
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(prc.ref_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -102,11 +112,11 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
             elseif (nameInSelect == "lastname" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = TRAQUERUtil.cleanStringForEncryptedValueCp(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND pnc.lastname_first_letter = \$$(args_counter += 1)"
                 push!(queryArgs,filterValue[1])
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pnc.lastname_for_cp_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -116,7 +126,7 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
                 # Add a first filter on the first letter for performance
                 filterValue = lowercase(filterValue)
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pnc.firstname_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -136,12 +146,12 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
                 end
 
                 # Add a first filter on the year for performance
-                queryStringShared *= "
+                prequeryString *= "
                     AND pbc.year = \$$(args_counter += 1)"
                 push!(queryArgs,year(filterValue))
 
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pbc.birthdate_crypt, \$1)
                         = \$$(args_counter += 1) "
                 push!(
@@ -156,15 +166,15 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
                 # For arrays of string
                 if (haskey(paramsDict,"attributeTest")
                  && uppercase(paramsDict["attributeTest"]) == "IN")
-                    queryStringShared *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
+                    prequeryString *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
                     push!(queryArgs, unique(filterValue))
                 else
-                    queryStringShared *= " AND $nameInWhereClause ILIKE \$$(args_counter += 1) "
+                    prequeryString *= " AND $nameInWhereClause ILIKE \$$(args_counter += 1) "
                     push!(queryArgs,("%" * filterValue * "%"))
                 end
 
             elseif (paramsDict["attributeType"] == "enum")
-                queryStringShared *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
+                prequeryString *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
                 if isa(filterValue, String)
                     push!(queryArgs, [filterValue])
                 elseif isa(filterValue, Vector{String})
@@ -182,7 +192,7 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
                     )
                 end
             else
-                queryStringShared *= " AND $nameInWhereClause = \$$(args_counter += 1) "
+                prequeryString *= " AND $nameInWhereClause = \$$(args_counter += 1) "
                 push!(queryArgs, filterValue)
             end
 
@@ -214,18 +224,29 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
     end # ENDOF for paramsDict in filtersAndSortings
 
     # Create the 'ORDER BY' part
-    # NOTE : 'ORDER BY' doit utilisé dans la pré-requête mais aussi dans
-    #         la  requête principale
-    orderByClause = ""
+    # NOTE : 'ORDER BY' must also appear in the final query because  final query does not
+    #         guarantee to keep the order from prequery
     if (length(sortings) > 0)
-        orderByClause = " ORDER BY " * join(sortings,",")
+        prequeryString *= " ORDER BY " * join(sortings,",")
     end
+    prequeryString *= "
+    LIMIT \$$(args_counter += 1) "
+    prequeryString *= "
+    OFFSET \$$(args_counter += 1)"
 
+    # NOTE: This will equal to missing if pageSize is missing
+    #       which results in passing NULL to the query which does work
+    offset = (pageNum - 1) * pageSize
 
     queryString *= (
-        queryStringUsing
-        *"SELECT a.*,
-                 u.name AS unit_name"
+        "
+        WITH prequery AS (
+            $prequeryString
+        )
+        "
+        *"
+        SELECT prequery.*
+        "
     )
 
     # Add some columns for the decrypted values
@@ -238,25 +259,32 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
         "
     end
 
-    queryString *= queryStringShared
+    queryString *= "
+        FROM prequery
+    "
 
-    if (length(sortings) > 0)
-        queryString *= " ORDER BY " * join(sortings,",")
+    # Add the required joins for the crypted values
+    if !ismissing(cryptPwd)
+        queryString *= "
+            JOIN patient_birthdate_crypt pbc
+                ON  pbc.year = prequery.patient_birth_year
+                AND pbc.id = prequery.patient_birthdate_crypt_id
+            JOIN patient_name_crypt pnc
+                ON  pnc.lastname_first_letter = prequery.patient_lastname_first_letter
+                AND pnc.id = prequery.patient_name_crypt_id
+            JOIN patient_ref_crypt prc
+                ON  prc.one_char = prequery.patient_ref_one_char
+                AND prc.id = prequery.patient_ref_crypt_id
+        "
     end
-    queryString *= "
-    LIMIT \$$(args_counter += 1) "
-    queryString *= "
-    OFFSET \$$(args_counter += 1)"
-
-    # NOTE: This will equal to missing if pageSize is missing
-    #       which results in passing NULL to the query which does work
-    offset = (pageNum - 1) * pageSize
 
     objects = missing
 
     dbconn = TRAQUERUtil.openDBConn()
 
     try
+
+        # println(queryString)
 
         objects = execute_plain_query(queryString,
                                      [queryArgs...,pageSize,offset], # queryArgs
@@ -281,6 +309,8 @@ function AnalysisRequestCtrl.getAnalysesRequestsForListing(
 
     totalRecords = typemax(Int64)
 
+    # Final sorting of the dataframe because the final query does not guarantee to respect
+    # the order of the prequery
     if length(dfSortings) > 0
         sort!(objects,dfSortings)
     end

--- a/src/Controller/AnalysisResultCtrl/getAnalysesResultsForListing.jl
+++ b/src/Controller/AnalysisResultCtrl/getAnalysesResultsForListing.jl
@@ -16,7 +16,7 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
 
     args_counter = 0
     queryString = ""
-    queryStringUsing = ""
+    prequeryString = ""
     queryArgs::Vector{Any} = []
 
     # If crypt password is given, set it as the first argument of the query
@@ -24,7 +24,18 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
         push!(queryArgs,cryptPwd)
     end
 
-    queryStringShared = "
+    prequeryString = "
+    SELECT a.*,
+
+           -- The following are for joining with the main query
+           p.birth_year AS patient_birth_year,
+           p.birthdate_crypt_id AS patient_birthdate_crypt_id,
+           p.lastname_first_letter AS patient_lastname_first_letter,
+           p.name_crypt_id AS patient_name_crypt_id,
+           p.ref_one_char AS patient_ref_one_char,
+           p.ref_crypt_id AS patient_ref_crypt_id
+
+
     FROM analysis_result a
     LEFT JOIN stay s -- an analysis may not have a corresponding stay
         ON a.stay_id = s.id
@@ -33,7 +44,7 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
     "
 
     if !ismissing(cryptPwd)
-        queryStringShared *= "
+        prequeryString *= "
         JOIN analysis_ref_crypt arc
             ON a.ref_one_char = arc.one_char
             AND a.ref_crypt_id = arc.id
@@ -43,13 +54,13 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
         JOIN patient_name_crypt pnc
             ON  pnc.lastname_first_letter = p.lastname_first_letter
             AND pnc.id = p.name_crypt_id
-        INNER JOIN patient_ref_crypt prc
+        JOIN patient_ref_crypt prc
             ON  prc.one_char = p.ref_one_char
             AND prc.id = p.ref_crypt_id
         "
     end
 
-    queryStringShared *= "
+    prequeryString *= "
     WHERE 1 = 1 -- for convenience
     "
 
@@ -92,11 +103,11 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
             if (nameInSelect == "analysis_ref" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = lowercase(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND arc.one_char = \$$(args_counter += 1)"
                 push!(queryArgs, AnalysisResultCtrl.getRefOneChar(filterValue))
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(arc.ref_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -105,11 +116,11 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
             elseif (nameInSelect == "patient_ref" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = lowercase(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND prc.one_char = \$$(args_counter += 1)"
                 push!(queryArgs, PatientCtrl.getRefOneChar(filterValue))
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(prc.ref_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -118,11 +129,11 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
             elseif (nameInSelect == "lastname" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = TRAQUERUtil.cleanStringForEncryptedValueCp(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND pnc.lastname_first_letter = \$$(args_counter += 1)"
                 push!(queryArgs,filterValue[1])
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pnc.lastname_for_cp_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -132,7 +143,7 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
                 # Add a first filter on the first letter for performance
                 filterValue = lowercase(filterValue)
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pnc.firstname_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -152,12 +163,12 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
                 end
 
                 # Add a first filter on the year for performance
-                queryStringShared *= "
+                prequeryString *= "
                     AND pbc.year = \$$(args_counter += 1)"
                 push!(queryArgs,year(filterValue))
 
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pbc.birthdate_crypt, \$1)
                         = \$$(args_counter += 1) "
                 push!(
@@ -172,15 +183,15 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
                 # For arrays of string
                 if (haskey(paramsDict,"attributeTest")
                  && uppercase(paramsDict["attributeTest"]) == "IN")
-                    queryStringShared *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
+                    prequeryString *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
                     push!(queryArgs, unique(filterValue))
                 else
-                    queryStringShared *= " AND $nameInWhereClause ILIKE \$$(args_counter += 1) "
+                    prequeryString *= " AND $nameInWhereClause ILIKE \$$(args_counter += 1) "
                     push!(queryArgs,("%" * filterValue * "%"))
                 end
 
             elseif (paramsDict["attributeType"] == "enum")
-                queryStringShared *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
+                prequeryString *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
                 if isa(filterValue, String)
                     push!(queryArgs, [filterValue])
                 elseif isa(filterValue, Vector{String})
@@ -198,7 +209,7 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
                     )
                 end
             else
-                queryStringShared *= " AND $nameInWhereClause = \$$(args_counter += 1) "
+                prequeryString *= " AND $nameInWhereClause = \$$(args_counter += 1) "
                 push!(queryArgs, filterValue)
             end
 
@@ -211,6 +222,12 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
         #       various types of joins no longer preserve the order of the
         #       left dataframe
         #       (see https://github.com/JuliaData/DataFrames.jl/blob/main/NEWS.md#other-relevant-changes)
+
+        # Add default sorting on 'request_time'
+        if paramsDict["field"] == "request_time" && ismissing(paramsDict["sorting"])
+            paramsDict["sorting"] = -1
+        end
+
         if !ismissing(paramsDict["sorting"])
 
             # For the SQL query
@@ -219,25 +236,36 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
 
             # For the final dataframe sort
             _rev = (paramsDict["sorting"] == 1) ? false : true
-            push!(dfSortings,
-                  order(Symbol(nameInSelect), rev = _rev))
+            push!(dfSortings, order(Symbol(nameInSelect), rev = _rev))
 
         end
 
     end # ENDOF for paramsDict in filtersAndSortings
 
     # Create the 'ORDER BY' part
-    # NOTE : 'ORDER BY' doit utilisé dans la pré-requête mais aussi dans
-    #         la  requête principale
-    orderByClause = ""
+    # NOTE : 'ORDER BY' must also appear in the final query because  final query does not
+    #         guarantee to keep the order from prequery
     if (length(sortings) > 0)
-        orderByClause = " ORDER BY " * join(sortings,",")
+        prequeryString *= " ORDER BY " * join(sortings,",")
     end
+    prequeryString *= "
+    LIMIT \$$(args_counter += 1) "
+    prequeryString *= "
+    OFFSET \$$(args_counter += 1)"
 
+    # NOTE: This will equal to missing if pageSize is missing
+    #       which results in passing NULL to the query which does work
+    offset = (pageNum - 1) * pageSize
 
     queryString *= (
-        queryStringUsing
-        *"SELECT a.*"
+        "
+        WITH prequery AS (
+            $prequeryString
+        )
+        "
+        *"
+        SELECT prequery.*
+        "
     )
 
     # Add some columns for the decrypted values
@@ -251,25 +279,35 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
         "
     end
 
-    queryString *= queryStringShared
+    queryString *= "
+        FROM prequery
+    "
 
-    if (length(sortings) > 0)
-        queryString *= " ORDER BY " * join(sortings,",")
+    # Add the required joins for the crypted values
+    if !ismissing(cryptPwd)
+        queryString *= "
+            JOIN analysis_ref_crypt arc
+                ON arc.one_char = prequery.ref_one_char
+                AND arc.id = prequery.ref_crypt_id
+            JOIN patient_birthdate_crypt pbc
+                ON  pbc.year = prequery.patient_birth_year
+                AND pbc.id = prequery.patient_birthdate_crypt_id
+            JOIN patient_name_crypt pnc
+                ON  pnc.lastname_first_letter = prequery.patient_lastname_first_letter
+                AND pnc.id = prequery.patient_name_crypt_id
+            JOIN patient_ref_crypt prc
+                ON  prc.one_char = prequery.patient_ref_one_char
+                AND prc.id = prequery.patient_ref_crypt_id
+        "
     end
-    queryString *= "
-    LIMIT \$$(args_counter += 1) "
-    queryString *= "
-    OFFSET \$$(args_counter += 1)"
-
-    # NOTE: This will equal to missing if pageSize is missing
-    #       which results in passing NULL to the query which does work
-    offset = (pageNum - 1) * pageSize
 
     objects = missing
 
     dbconn = TRAQUERUtil.openDBConn()
 
     try
+
+        println(queryString)
 
         objects = execute_plain_query(queryString,
                                      [queryArgs...,pageSize,offset], # queryArgs
@@ -294,6 +332,8 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
 
     totalRecords = typemax(Int64)
 
+    # Final sorting of the dataframe because the final query does not guarantee to respect
+    # the order of the prequery
     if length(dfSortings) > 0
         sort!(objects,dfSortings)
     end

--- a/src/Controller/AnalysisResultCtrl/getAnalysesResultsForListing.jl
+++ b/src/Controller/AnalysisResultCtrl/getAnalysesResultsForListing.jl
@@ -307,7 +307,7 @@ function AnalysisResultCtrl.getAnalysesResultsForListing(
 
     try
 
-        println(queryString)
+        # println(queryString)
 
         objects = execute_plain_query(queryString,
                                      [queryArgs...,pageSize,offset], # queryArgs

--- a/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
+++ b/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
@@ -199,9 +199,12 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
         #       various types of joins no longer preserve the order of the
         #       left dataframe
         #       (see https://github.com/JuliaData/DataFrames.jl/blob/main/NEWS.md#other-relevant-changes)
+
+        # Add default sorting on 'event_ref_time'
         if paramsDict["field"] == "event_ref_time" && ismissing(paramsDict["sorting"])
             paramsDict["sorting"] = -1
         end
+
         if !ismissing(paramsDict["sorting"])
 
             # For the SQL query

--- a/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
+++ b/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
@@ -309,7 +309,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
     dbconn = TRAQUERUtil.openDBConn()
     try
 
-        println(queryString)
+        # println(queryString)
 
         objects = execute_plain_query(queryString,
                                      [queryArgs...,pageSize,offset], # queryArgs

--- a/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
+++ b/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
@@ -213,8 +213,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
 
             # For the final dataframe sort
             _rev = (paramsDict["sorting"] == 1) ? false : true
-            push!(dfSortings,
-                  order(Symbol(nameInSelect), rev = _rev))
+            push!(dfSortings, order(Symbol(nameInSelect), rev = _rev))
 
         end
 
@@ -309,6 +308,8 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
 
     totalRecords = typemax(Int64)
 
+    # Final sorting of the dataframe because the final query does not guarantee to respect
+    # the order of the prequery
     if length(dfSortings) > 0
         sort!(objects,dfSortings)
     end

--- a/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
+++ b/src/Controller/InfectiousStatusCtrl/getInfectiousStatusForListing.jl
@@ -15,7 +15,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
 
     args_counter = 0
     queryString = ""
-    queryStringUsing = ""
+    prequeryString = ""
     queryArgs::Vector{Any} = []
 
     # If crypt password is given, set it as the first argument of the query
@@ -23,7 +23,37 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
         push!(queryArgs,cryptPwd)
     end
 
-    queryStringShared = "
+    prequeryString = "
+        SELECT  p.id AS patient_id,
+                p.traquer_ref AS traquer_ref,
+                p.is_hospitalized AS patient_is_hospitalized,
+                ist.id AS infectious_status_id,
+                ist.ref_time AS ref_time,
+                ist.infectious_status,
+                ist.infectious_agent,
+                ist.is_confirmed,
+                ist.is_current,
+                era.id AS event_id,
+                era.response_time AS event_response_time,
+                era.response_user_id AS event_response_user_id,
+                era.response_comment AS event_response_comment,
+                era.responses_types AS event_responses_types,
+                era.event_type AS event_type,
+                era.ref_time AS event_ref_time,
+                era.is_pending AS event_is_pending,
+                patient_current_unit.code_name AS current_unit_code_name,
+                patient_current_unit.name AS current_unit_name,
+                o.id AS outbreak_id,
+                o.name AS outbreak_name,
+
+                -- The following are for joining with the main query
+                p.birth_year AS patient_birth_year,
+                p.birthdate_crypt_id AS patient_birthdate_crypt_id,
+                p.lastname_first_letter AS patient_lastname_first_letter,
+                p.name_crypt_id AS patient_name_crypt_id,
+                p.ref_one_char AS patient_ref_one_char,
+                p.ref_crypt_id AS patient_ref_crypt_id
+
         FROM infectious_status ist
         INNER JOIN event_requiring_attention era
           ON era.infectious_status_id = ist.id
@@ -38,7 +68,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
     "
 
     if !ismissing(cryptPwd)
-        queryStringShared *= "
+        prequeryString *= "
           INNER JOIN patient_birthdate_crypt pbc
             ON  pbc.year = p.birth_year
             AND pbc.id = p.birthdate_crypt_id
@@ -51,7 +81,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
         "
     end
 
-    queryStringShared *= "
+    prequeryString *= "
     WHERE 1 = 1 -- for convenience
     "
 
@@ -94,11 +124,11 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
             if (nameInSelect == "patient_ref" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = lowercase(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND prc.one_char = \$$(args_counter += 1)"
                 push!(queryArgs, PatientCtrl.getRefOneChar(filterValue))
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(prc.ref_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -107,11 +137,11 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
             elseif (nameInSelect == "lastname" && !ismissing(cryptPwd))
                 # Add a first filter on the first letter for performance
                 filterValue = TRAQUERUtil.cleanStringForEncryptedValueCp(filterValue)
-                queryStringShared *= "
+                prequeryString *= "
                     AND pnc.lastname_first_letter = \$$(args_counter += 1)"
                 push!(queryArgs,filterValue[1])
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pnc.lastname_for_cp_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -120,7 +150,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
             elseif (nameInSelect == "firstname" && !ismissing(cryptPwd))
                 filterValue = lowercase(filterValue)
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pnc.firstname_crypt, \$1)
                         ILIKE \$$(args_counter += 1) "
                 push!(queryArgs,(filterValue * "%"))
@@ -140,12 +170,12 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
                 end
 
                 # Add a first filter on the year for performance
-                queryStringShared *= "
+                prequeryString *= "
                     AND pbc.year = \$$(args_counter += 1)"
                 push!(queryArgs,year(filterValue))
 
                 # Add the filter itself
-                queryStringShared *= "
+                prequeryString *= "
                     AND pgp_sym_decrypt(pbc.birthdate_crypt, \$1)
                         = \$$(args_counter += 1) "
                 push!(
@@ -160,15 +190,15 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
                 # For arrays of string
                 if (haskey(paramsDict,"attributeTest")
                  && uppercase(paramsDict["attributeTest"]) == "IN")
-                    queryStringShared *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
+                    prequeryString *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
                     push!(queryArgs, unique(filterValue))
                 else
-                    queryStringShared *= " AND $nameInWhereClause ILIKE \$$(args_counter += 1) "
+                    prequeryString *= " AND $nameInWhereClause ILIKE \$$(args_counter += 1) "
                     push!(queryArgs,("%" * filterValue * "%"))
                 end
 
             elseif (paramsDict["attributeType"] == "enum")
-                queryStringShared *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
+                prequeryString *= " AND $nameInWhereClause = ANY(\$$(args_counter += 1)) "
                 if isa(filterValue, String)
                     push!(queryArgs, [filterValue])
                 elseif isa(filterValue, Vector{String})
@@ -186,7 +216,7 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
                     )
                 end
             else
-                queryStringShared *= " AND $nameInWhereClause = \$$(args_counter += 1) "
+                prequeryString *= " AND $nameInWhereClause = \$$(args_counter += 1) "
                 push!(queryArgs, filterValue)
             end
 
@@ -222,37 +252,29 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
     # Create the 'ORDER BY' part
     # NOTE : 'ORDER BY' doit utilisé dans la pré-requête mais aussi dans
     #         la  requête principale
-    orderByClause = ""
     if (length(sortings) > 0)
-        orderByClause = " ORDER BY " * join(sortings,",")
+        prequeryString *= " ORDER BY " * join(sortings,",")
     end
+    prequeryString *= "
+    LIMIT \$$(args_counter += 1) "
+    prequeryString *= "
+    OFFSET \$$(args_counter += 1)"
+
+    # NOTE: This will equal to missing if pageSize is missing
+    #       which results in passing NULL to the query which does work
+    offset = (pageNum - 1) * pageSize
 
 
-    queryString *= (queryStringUsing
-        * "SELECT p.id AS patient_id,
-                  p.traquer_ref AS traquer_ref,
-                  p.birthdate_crypt_id AS birthdate_crypt_id,
-                  p.birthdate_crypt_id AS birth_year,
-                  p.is_hospitalized AS patient_is_hospitalized,
-                  ist.id AS infectious_status_id,
-                  ist.ref_time AS ref_time,
-                  ist.infectious_status,
-                  ist.infectious_agent,
-                  ist.is_confirmed,
-                  ist.is_current,
-                  era.id AS event_id,
-                  era.response_time AS event_response_time,
-                  era.response_user_id AS event_response_user_id,
-                  era.response_comment AS event_response_comment,
-                  era.responses_types AS event_responses_types,
-                  era.event_type AS event_type,
-                  era.ref_time AS event_ref_time,
-                  era.is_pending AS event_is_pending,
-                  patient_current_unit.code_name AS current_unit_code_name,
-                  patient_current_unit.name AS current_unit_name,
-                  o.id AS outbreak_id,
-                  o.name AS outbreak_name
-                  ")
+    queryString *= (
+        "
+        WITH prequery AS (
+            $prequeryString
+        )
+        "
+        *"
+        SELECT prequery.*
+        "
+    )
 
     # Add some columns for the decrypted values
     if !ismissing(cryptPwd)
@@ -264,24 +286,30 @@ function InfectiousStatusCtrl.getInfectiousStatusForListing(
         "
     end
 
-    queryString *= queryStringShared
-
-    if (length(sortings) > 0)
-        queryString *= " ORDER BY " * join(sortings,",")
+    queryString *= "
+        FROM prequery
+        "
+    # Add the required joins for the crypted values
+    if !ismissing(cryptPwd)
+        queryString *= "
+            JOIN patient_birthdate_crypt pbc
+              ON  pbc.year = prequery.patient_birth_year
+              AND pbc.id = prequery.patient_birthdate_crypt_id
+            JOIN patient_name_crypt pnc
+              ON  pnc.lastname_first_letter = prequery.patient_lastname_first_letter
+              AND pnc.id = prequery.patient_name_crypt_id
+            JOIN patient_ref_crypt prc
+              ON  prc.one_char = prequery.patient_ref_one_char
+              AND prc.id = prequery.patient_ref_crypt_id
+        "
     end
-    queryString *= "
-    LIMIT \$$(args_counter += 1) "
-    queryString *= "
-    OFFSET \$$(args_counter += 1)"
-
-    # NOTE: This will equal to missing if pageSize is missing
-    #       which results in passing NULL to the query which does work
-    offset = (pageNum - 1) * pageSize
 
     objects = missing
 
     dbconn = TRAQUERUtil.openDBConn()
     try
+
+        println(queryString)
 
         objects = execute_plain_query(queryString,
                                      [queryArgs...,pageSize,offset], # queryArgs

--- a/src/Controller/InfectiousStatusCtrl/upsert.jl
+++ b/src/Controller/InfectiousStatusCtrl/upsert.jl
@@ -1,7 +1,8 @@
 function InfectiousStatusCtrl.upsert!(
     infectiousStatus::InfectiousStatus,
     dbconn::LibPQ.Connection
-    ;createEventForStatus::Bool = true
+    ;createEventForStatus::Bool = true,
+    setNewEventAsPending::Bool = true
 )
 
     # Do not create the status if it was deleted
@@ -41,7 +42,7 @@ function InfectiousStatusCtrl.upsert!(
             # Create the event requiring attention
             eventRequiringAttention = EventRequiringAttention(
                 infectiousStatus = infectiousStatus,
-                isPending = true,
+                isPending = if setNewEventAsPending true else false end,
                 eventType = EventRequiringAttentionType.new_status,
                 refTime = infectiousStatus.refTime
             )

--- a/src/Controller/MaintenanceCtrl/_def.jl
+++ b/src/Controller/MaintenanceCtrl/_def.jl
@@ -1,3 +1,4 @@
 function resetDatabase end
 function resetInfectiousStatusesOutbreaksAndExposures end
 function resetInfectiousStatusesOutbreaksAndExposuresAndReprocessPatientData end
+function importExistingConfirmedStatuses end

--- a/src/Controller/MaintenanceCtrl/_imp.jl
+++ b/src/Controller/MaintenanceCtrl/_imp.jl
@@ -1,3 +1,4 @@
 include("resetDatabase.jl")
 include("resetInfectiousStatusesOutbreaksAndExposures.jl")
 include("resetInfectiousStatusesOutbreaksAndExposuresAndReprocessPatientData.jl")
+include("importExistingConfirmedStatuses.jl")

--- a/src/Controller/MaintenanceCtrl/importExistingConfirmedStatuses.jl
+++ b/src/Controller/MaintenanceCtrl/importExistingConfirmedStatuses.jl
@@ -1,0 +1,59 @@
+function MaintenanceCtrl.importExistingConfirmedStatuses(
+    filePath::String,
+    cryptStr::String,
+    dbconn::LibPQ.Connection
+)
+
+    df = XLSX.readtable(filePath,1) |> DataFrame
+
+    # return df
+
+    # The columns of the dataframe may be of type Any even if the elements are of other types.
+    # The following casting is a way to make sure that the columns are of the right type.
+    df.patient_ref = string.(df.patient_ref)
+    df.firstname = string.(df.firstname)
+    df.lastname = string.(df.lastname)
+    df.birthdate = Date.(df.birthdate)
+    df.infectious_status_ref_time = ZonedDateTime.(
+        DateTime.(df.infectious_status_ref_time),
+        TRAQUERUtil.getTimeZone()
+    )
+    df.infectious_agent = TRAQUERUtil.string2enum.(
+        InfectiousAgentCategory.INFECTIOUS_AGENT_CATEGORY, df.infectious_agent
+    )
+    df.infectious_status = TRAQUERUtil.string2enum.(
+        InfectiousStatusType.INFECTIOUS_STATUS_TYPE, df.infectious_status
+    )
+
+    for r in eachrow(df)
+
+        patient = PatientCtrl.createPatientIfNoExist(
+            r.firstname,
+            r.lastname,
+            r.birthdate,
+            r.patient_ref,
+            cryptStr,
+            dbconn
+        )
+
+        infectiousStatus = InfectiousStatus(
+            patient = patient,
+            infectiousAgent = r.infectious_agent,
+            infectiousStatus = r.infectious_status,
+            refTime = r.infectious_status_ref_time,
+            isConfirmed = true,
+        )
+
+        InfectiousStatusCtrl.upsert!(
+            infectiousStatus,
+            dbconn
+            ;setNewEventAsPending = false
+        )
+
+        InfectiousStatusCtrl.updateCurrentStatus(patient, dbconn)
+
+    end
+
+    return df
+
+end

--- a/src/Controller/PatientCtrl/retrievePatientsFromRef.jl
+++ b/src/Controller/PatientCtrl/retrievePatientsFromRef.jl
@@ -5,14 +5,14 @@ function PatientCtrl.retrievePatientsFromRef(ref::AbstractString,
     refOneChar = PatientCtrl.getRefOneChar(ref)
     queryString = "SELECT p.* FROM patient p
                    INNER JOIN public.patient_ref_crypt prc
-                      ON (p.ref_one_char = prc.one_char
-                        AND p.ref_crypt_id = prc.id)
+                      ON (
+                        p.ref_one_char = prc.one_char
+                        AND p.ref_crypt_id = prc.id
+                      )
                    WHERE prc.one_char = \$3
                      AND pgp_sym_decrypt(prc.ref_crypt, \$1) = \$2"
 
-    queryArgs = [encryptionStr,
-                 ref,
-                 refOneChar]
+    queryArgs = [encryptionStr, ref, refOneChar]
 
     patients = PostgresORM.execute_query_and_handle_result(
             queryString, Patient, queryArgs,

--- a/src/Controller/StayCtrl/getStaysForListing.jl
+++ b/src/Controller/StayCtrl/getStaysForListing.jl
@@ -290,7 +290,7 @@ function StayCtrl.getStaysForListing(
 
     objects = missing
 
-    println(queryString)
+    # println(queryString)
 
     dbconn = TRAQUERUtil.openDBConn()
     try

--- a/src/Controller/StayCtrl/getStaysForListing.jl
+++ b/src/Controller/StayCtrl/getStaysForListing.jl
@@ -207,6 +207,12 @@ function StayCtrl.getStaysForListing(
         #       various types of joins no longer preserve the order of the
         #       left dataframe
         #       (see https://github.com/JuliaData/DataFrames.jl/blob/main/NEWS.md#other-relevant-changes)
+
+        # Add default sorting on 'in_time'
+        if paramsDict["field"] == "in_time" && ismissing(paramsDict["sorting"])
+            paramsDict["sorting"] = -1
+        end
+
         if !ismissing(paramsDict["sorting"])
 
             # For the SQL query

--- a/src/Controller/StayCtrl/getStaysForListing.jl
+++ b/src/Controller/StayCtrl/getStaysForListing.jl
@@ -276,6 +276,7 @@ function StayCtrl.getStaysForListing(
     queryString *= "
         FROM prequery
         "
+    # Add the required joins for the crypted values
     if !ismissing(cryptPwd)
         queryString *= "
             JOIN patient_birthdate_crypt pbc
@@ -316,6 +317,8 @@ function StayCtrl.getStaysForListing(
 
     totalRecords = typemax(Int64)
 
+    # Final sorting of the dataframe because the final query does not guarantee to respect
+    # the order of the prequery
     if length(dfSortings) > 0
         sort!(objects,dfSortings)
     end

--- a/src/Controller/StayCtrl/getStaysForListing.jl
+++ b/src/Controller/StayCtrl/getStaysForListing.jl
@@ -201,7 +201,13 @@ function StayCtrl.getStaysForListing(
 
             # For the SQL query
             _order = (paramsDict["sorting"] == 1) ? " ASC " : " DESC "
-            push!(sortings,nameInWhereClause * _order)
+
+            # Special treatment for stay.in_time
+            if nameInSelect == "in_time"
+                push!(sortings,"s.in_date" * _order)
+            else
+                push!(sortings,nameInWhereClause * _order)
+            end
 
             # For the final dataframe sort
             _rev = (paramsDict["sorting"] == 1) ? false : true
@@ -256,10 +262,12 @@ function StayCtrl.getStaysForListing(
 
     objects = missing
 
+    println(queryString)
+
     dbconn = TRAQUERUtil.openDBConn()
     try
 
-        objects = execute_plain_query(queryString,
+        @time objects = execute_plain_query(queryString,
                                      [queryArgs...,pageSize,offset], # queryArgs
                                       dbconn)
 

--- a/src/Controller/StayCtrl/getStaysForListing.jl
+++ b/src/Controller/StayCtrl/getStaysForListing.jl
@@ -249,8 +249,6 @@ function StayCtrl.getStaysForListing(
     #       which results in passing NULL to the query which does work
     offset = (pageNum - 1) * pageSize
 
-
-
     queryString *= (
         "
         WITH prequery AS (
@@ -260,7 +258,6 @@ function StayCtrl.getStaysForListing(
         *"
         SELECT prequery.*
         "
-
     )
 
     # Add some columns for the decrypted values

--- a/src/Controller/StayCtrl/getStaysWherePatientAtRisk.jl
+++ b/src/Controller/StayCtrl/getStaysWherePatientAtRisk.jl
@@ -14,7 +14,7 @@ outbreak.refTime:                            ⬇(= infectiousStatus.startTime = 
 Infectious status:                           🍎
 Isolation:                                      📢
 All stays:           [======]  [========][=========][========]   [========]
-stays at risk:                      ✓         ✓
+stays at risk:                      ✓         ✓                      ✓
 
 
 # Case where a carrier comes back for a new hospitalization:
@@ -24,7 +24,7 @@ outbreak.refTime:           ⬇(= hospitalizationInTime)
 Infectious status:     🍎
 Isolation:                            📢
 All stays:           [===]  [=====][====][===]    [========]
-stays at risk:         ✓       ✓     ✓
+stays at risk:         ✓       ✓     ✓               ✓
 
 
 # Case where we have several carriers. In that case the outbreak ref time is the lowest time
@@ -41,7 +41,7 @@ stays at risk:                                ✓               ✓
 
 
 
-# TODO
+# Case where the patient patient comes back many times
 
 Hospitalization:      [========]  [=====================]   [======================]
 outbreak.refTime:
@@ -51,7 +51,7 @@ All stays:            [===][===]  [====][=======][======]    [====][=======][===
 stays at risk:          ✓           ✓       ✓                 ✓
 
 
-# TODO
+# Case where the patient becomes negative after a few hospitalizations
 
 Hospitalization:      [========]  [=====================]   [======================]
 outbreak.refTime:

--- a/src/TRAQUER.jl
+++ b/src/TRAQUER.jl
@@ -310,7 +310,7 @@ module Controller
   end
 
   module MaintenanceCtrl
-    include("Controller/MaintenanceCtrl/MaintenanceCtrl-def.jl")
+    include("Controller/MaintenanceCtrl/_def.jl")
   end
 
   # Default CRUD actions are the base of the Controller module
@@ -393,7 +393,7 @@ include("Controller/WebApiUsageCtrl/WebApiUsageCtrl-imp.jl")
 include("Controller/SchedulerCtrl/_imp.jl")
 
 # MaintenanceCtrl
-include("Controller/MaintenanceCtrl/MaintenanceCtrl-imp.jl")
+include("Controller/MaintenanceCtrl/_imp.jl")
 
 # Custom implementation
 include(ENV["TRAQUER_CUSTOM_MODULE_IMPLEMENTATION_FILE"])

--- a/test/MaintenanceCtrl/runtests-importExistingConfirmedStatuses.jl
+++ b/test/MaintenanceCtrl/runtests-importExistingConfirmedStatuses.jl
@@ -1,0 +1,14 @@
+include("../runtests-prerequisite.jl")
+
+@testset "Test MaintenanceCtrl.importExistingConfirmedStatuses" begin
+    TRAQUERUtil.createDBConnAndExecute() do dbconn
+        MaintenanceCtrl.importExistingConfirmedStatuses(
+            joinpath(
+                TRAQUERUtil.getPendingInputFilesDir(),
+                "tmp/existing-confirmed-infectious-status.xlsx"
+            ),
+            cryptStr,
+            dbconn
+        )
+    end
+end


### PR DESCRIPTION
This PR fixes the following:

For some queries `pgp_sym_decrypt` was invoked on more rows than expected. 

For example when limiting the number of results using for example `LIMIT 10` one could have expected `pgp_sym_decrypt` to be invoked only 10 times but that is not the case.

Here is what chatGPT says about this:
```
The LIMIT 10 clause does indeed limit the final result set to 10 rows, but the performance hit you're seeing isn't related to the number of rows in the output. It's related to the computation being done for each row.

Here's what happens:

    With the Line Commented Out: Your query joins tables, applies filtering conditions, and sorts the results. The LIMIT 10 ensures that only 10 rows are returned, and given the use of ORDER BY, the database can utilize optimization techniques such as "top-N heapsort" to efficiently find the top 10 rows without having to fully sort the entire result set. Your original query without the decryption step took about 244 milliseconds.

    With the Line Uncommented (Decryption Involved): Once you introduce the pgp_sym_decrypt function, for each row in the join result between patient, stay, unit, and patient_birthdate_crypt, the database must decrypt the birthdate_crypt column. This decryption operation is computationally intensive. It's not just about how many rows you output; it's about how many rows the decryption function has to be applied to during the process of figuring out which 10 rows to output.

Remember, the query is doing a join first and then ordering the results to find the top 10 based on s.in_date. So even if only 10 rows are in the final output, the decryption function gets applied many more times in the process.

From your query plan, we can see that the decryption function is applied 14,735 times (as indicated by rows=14735), as this is the number of rows in the join result. This repetitive decryption for each of those rows dramatically increases the query's execution time.

To make this clearer: The LIMIT 10 does help, but only after all the decryption has been done. If you didn't have the LIMIT, you'd be decrypting AND then transmitting more data, which would take even longer. But even with the LIMIT, you still have to do all the decryption to determine which 10 rows to return.
```

The workaround is to use a prequery